### PR TITLE
Improve READMEs

### DIFF
--- a/core/test-run-controller/README.md
+++ b/core/test-run-controller/README.md
@@ -1,16 +1,58 @@
-# `@testring/test-run-controller`
+# @testring/test-run-controller
 
+测试运行控制器，负责调度测试文件并管理测试工作进程。该模块是 testring 核心的一部分，
+通过队列的方式顺序或并行执行测试，同时提供重试和插件钩子等功能。
 
+## 功能概述
+- 按队列依次执行测试文件
+- 支持本地进程或多子进程并行执行
+- 测试失败的重试及延迟控制
+- 通过插件钩子扩展测试流程
+- 统一管理测试运行产生的错误
 
-## Install
-Using npm:
-
-```
+## 安装
+```bash
 npm install --save-dev @testring/test-run-controller
 ```
-
-or using yarn:
-
-```
+或使用 yarn:
+```bash
 yarn add @testring/test-run-controller --dev
 ```
+
+## 基本使用
+```typescript
+import { TestRunController } from '@testring/test-run-controller';
+import { TestWorker } from '@testring/test-worker';
+import { loggerClient } from '@testring/logger';
+
+const controller = new TestRunController(config, new TestWorker(config));
+
+const errors = await controller.runQueue(testFiles);
+if (errors) {
+  loggerClient.error('测试失败数量:', errors.length);
+}
+```
+## 配置要点
+- **workerLimit**: `number | 'local'` 指定并发的工作进程数，`local` 表示在当前进程运行。
+- **retryCount**: 测试失败时的最大重试次数。
+- **retryDelay**: 重试前的等待时间（毫秒）。
+- **bail**: 一旦出现失败是否立即终止所有测试。
+- **testTimeout**: 单个测试的超时时间。
+
+## 插件钩子
+`TestRunController` 继承自 `PluggableModule`，暴露以下钩子供插件使用：
+- `beforeRun` / `afterRun` 运行队列前后触发
+- `beforeTest` / `afterTest` 单个测试开始与结束
+- `beforeTestRetry` 测试重试之前
+- `shouldNotExecute` 决定是否整体跳过队列
+- `shouldNotStart` 控制某个测试是否跳过
+- `shouldNotRetry` 控制某个失败测试是否重试
+
+## 错误处理与重试
+执行过程中产生的错误会被收集到内部数组中。若配置了重试，当测试失败且未超过
+`retryCount` 时会在 `retryDelay` 后再次加入队列执行。
+
+## 与其它模块配合
+通常与 `@testring/test-worker`、`@testring/logger` 以及 `@testring/fs-store` 等模块配合
+使用。可通过插件机制接入自定义逻辑，例如截图、环境准备或自定义报告等。
+

--- a/core/testring/README.md
+++ b/core/testring/README.md
@@ -1,16 +1,38 @@
-# `testring`
+# testring
 
-> Main package with CLI interface and test API.
+主入口包，包含命令行工具和可编程的测试 API。
 
-## Install
-Using npm:
+## 功能概述
+- 提供 `testring` 命令用于执行测试
+- 暴露 `run` API 供脚本中直接调用
+- 集成所有核心模块与插件系统
 
-```
+## 安装
+```bash
 npm install --save-dev testring
 ```
-
-or using yarn:
-
-```
+或使用 yarn:
+```bash
 yarn add testring --dev
 ```
+
+## CLI 使用示例
+```bash
+# 默认运行配置文件中的测试
+npx testring
+
+# 指定测试路径
+npx testring run --tests "./tests/**/*.spec.js"
+```
+## API 使用示例
+```typescript
+import run from 'testring';
+
+await run({
+  tests: './tests/**/*.spec.js',
+  workerLimit: 2,
+});
+```
+
+该包仅对外暴露基础启动能力，更多高级功能请参考各子模块文档。
+

--- a/packages/browser-proxy/README.md
+++ b/packages/browser-proxy/README.md
@@ -1,16 +1,28 @@
-# `@testring/browser-proxy`
+# @testring/browser-proxy
 
+浏览器代理服务，用于在测试过程中协调浏览器插件与主进程之间的通信。
 
+## 功能概述
+- 管理浏览器端插件的生命周期
+- 提供 WebSocket 通道转发消息
+- 支持在独立进程中运行代理以减少主进程负载
 
-## Install
-Using npm:
-
-```
+## 安装
+```bash
 npm install --save-dev @testring/browser-proxy
 ```
-
-or using yarn:
-
-```
+或使用 yarn:
+```bash
 yarn add @testring/browser-proxy --dev
 ```
+
+## 基本用法
+```typescript
+import { browserProxyControllerFactory } from '@testring/browser-proxy';
+import { transport } from '@testring/transport';
+
+const controller = browserProxyControllerFactory(transport);
+// 在插件中注册或启动浏览器代理
+```
+该模块通常与浏览器自动化插件一起使用，负责在浏览器与 Node.js 进程之间传递命令和事件。
+


### PR DESCRIPTION
## Summary
- expand documentation for `@testring/test-run-controller`
- document main `testring` package usage
- flesh out browser-proxy usage details

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d46b691cc832b9753f4bad92f6a55